### PR TITLE
Allow flycheck compile in temporary file.

### DIFF
--- a/flycheck-clang-tidy.el
+++ b/flycheck-clang-tidy.el
@@ -22,6 +22,7 @@
 ;;; Code:
 
 (require 'flycheck)
+(require 'json)
 
 (flycheck-def-config-file-var flycheck-clang-tidy c/c++-clang-tidy ".clang-tidy"
   :safe #'stringp)
@@ -40,6 +41,45 @@ CMake option to get this output)."
         (file-name-directory config_file_location)
       (message "Unable to find config file for %s, you need to create .clang-tidy file in your project root" checker))))
 
+(defun flycheck-clang-tidy-compile-command (file)
+  "Fetch compile command for FILE."
+  (let* ((cmds-file (concat (file-name-as-directory flycheck-clang-tidy-build-path)
+                            "compile_commands.json"))
+         (cmds (json-read-file cmds-file)))
+    (seq-find (lambda (cmd) (string= (alist-get 'file cmd) file)) cmds)))
+
+(defun flycheck-clang-tidy-temp-compile-command (file source)
+  "Return compile command for FILE with source located in SOURCE."
+  (let* ((cmd (flycheck-clang-tidy-compile-command file))
+         (directory (alist-get 'directory cmd))
+         (command (alist-get 'command cmd)))
+    (list (cons 'directory directory)
+          (cons 'command (replace-regexp-in-string (regexp-quote file)
+                                                   source command))
+          (cons 'file source))))
+
+(defun flycheck-clang-tidy-make-temp-compile-command (file source)
+  "Create a temporary build command file for FILE with SOURCE."
+  (let* ((directory (flycheck-temp-dir-system))
+         (cmds-dir (file-name-as-directory (make-temp-name (expand-file-name "flycheck" directory))))
+         (cmds-file (concat cmds-dir "compile_commands.json"))
+         (cmd (flycheck-clang-tidy-temp-compile-command file source)))
+    (prog1 cmds-dir
+      (mkdir cmds-dir)
+      (with-temp-file cmds-file
+        (insert (json-encode (vector cmd)))))))
+
+(defun flycheck-clang-tidy-inplace-build-command ()
+  "Generate temporary compile_commands.json file.
+
+This functions parses the compile_commands.json file and generate
+a new one for the flycheck temporary source file so that
+clang-tidy understand what to do with it."
+  (let ((source (flycheck-save-buffer-to-temp #'flycheck-temp-file-inplace)))
+    (format "-p=%s"
+            (flycheck-clang-tidy-make-temp-compile-command (buffer-file-name)
+                                                           source))))
+
 (flycheck-define-checker c/c++-clang-tidy
   "A C/C++ syntax checker using clang-tidy.
 
@@ -47,8 +87,8 @@ See URL `https://github.com/ch1bo/flycheck-clang-tidy'."
   :command ("clang-tidy"
             ;; TODO: clang-tidy expects config file contents, no way to change path
             ;; (config-file "-config=" flycheck-clang-tidy)
-            (option "-p" flycheck-clang-tidy-build-path)
-            source-original)
+            (eval (flycheck-clang-tidy-inplace-build-command))
+            (eval (flycheck-save-buffer-to-temp #'flycheck-temp-file-inplace)))
   :error-patterns
   ((error line-start (file-name) ":" line ":" column ": error: "
           (message (one-or-more not-newline) "\n"


### PR DESCRIPTION
Parse the command_compiles.json to extract the compile command for the current
file. Generate a new one in a temporary directory with the compile command
modified to replace the file name with the temporary flycheck file name.