### PR TITLE
Replaced "source" to "source-original"

### DIFF
--- a/flycheck-clang-tidy.el
+++ b/flycheck-clang-tidy.el
@@ -171,7 +171,7 @@ See URL `https://github.com/ch1bo/flycheck-clang-tidy'."
             (eval (concat "-extra-arg=-I" (flycheck-clang-tidy-current-source-dir)))
             (eval (concat "-config=" (flycheck-clang-tidy-get-config)))
             (eval flycheck-clang-tidy-extra-options)
-            source)
+            source-original)
   :error-patterns
   ((error line-start (file-name) ":" line ":" column ": error: "
           (message) line-end)


### PR DESCRIPTION
This is so that clang-tidy would use the original C++ file as input rather than
a copy of it under temporary directory.

Even on ubuntu 20.04 I don't think flycheck-clang-tidy was working correctly, because compilation database file was not being located.   With this change `flycheck-list-errors` now works correctly on CentOS 7.
